### PR TITLE
chore: bump boto3 to 1.40.31

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.40.30
+boto3==1.40.31
 psycopg2-binary==2.9.10
 python-dotenv==1.1.1
 py7zr==1.0.0


### PR DESCRIPTION
This PR updates the boto3 dependency from 1.40.30 → 1.40.31.

Keeps compatibility with botocore 1.40.31

Tested locally, no breaking changes observed

Prepares repo for safe deployment on Railway