### PR TITLE
chore: bump boto3 to 1.40.32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.40.31
+boto3==1.40.32
 psycopg2-binary==2.9.10
 python-dotenv==1.1.1
 py7zr==1.0.0


### PR DESCRIPTION
- Updated boto3 from 1.40.31 → 1.40.32
- Keeps AWS SDK up to date with latest bug fixes and improvements
- Tested in PR environment, backup to R2 works correctly
