### PR TITLE
chore: bump boto3 to 1.40.33 and refresh deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.40.32
+boto3==1.40.33
 psycopg2-binary==2.9.10
 python-dotenv==1.1.1
 py7zr==1.0.0


### PR DESCRIPTION
This PR updates dependencies to the latest stable versions:

- boto3: 1.40.32 → 1.40.33
- psycopg2-binary: kept at 2.9.10
- python-dotenv: kept at 1.1.1
- py7zr: kept at 1.0.0
- schedule: kept at 1.2.2

✅ Verified on Railway using `deps-update` branch.  
No breaking changes observed.  
Ready to merge into `main`.
