### PR TITLE
chore: bump deps and refactor Dockerfile to multi-stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.12-slim
 RUN apt-get update && \
     apt-get install -y postgresql-client gcc libpq-dev gzip && \
     rm -rf /var/lib/apt/lists/*
+	
+RUN pip install --upgrade pip setuptools wheel
 
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS builder
 
 RUN apt-get update && \
-    apt-get install -y postgresql-client gcc libpq-dev gzip && \
+    apt-get install -y gcc libpq-dev && \
     rm -rf /var/lib/apt/lists/*
-	
+
 RUN pip install --upgrade pip setuptools wheel
 
 COPY requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r /app/requirements.txt
+RUN pip install --prefix=/install -r /app/requirements.txt
+
+FROM python:3.12-slim
+
+RUN apt-get update && \
+    apt-get install -y postgresql-client gzip && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /install /usr/local
 
 COPY main.py /app/main.py
 


### PR DESCRIPTION
Bumped boto3 to 1.40.33 and refreshed dependencies

Upgraded pip, setuptools, and wheel to latest in Docker build

Refactored Dockerfile to use a multi-stage build:

builder stage installs Python deps with gcc and libpq-dev

final stage contains only runtime deps (postgresql-client, gzip)

results in a smaller, cleaner runtime image

Already tested in branch build. Ready to merge. 