### PR TITLE
fix: resolve pg_dump version mismatch by upgrading to PostgreSQL 18 client

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -14,6 +14,7 @@ All contributions are welcome — including bug reports, documentation improveme
 
 > `main` is considered stable and production ready.
 > Please open an issue before submitting new features or behavior changes.
+> Bug fixes and documentation updates can be submitted directly.
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bookworm AS builder
+FROM python:3.13-slim AS builder
 
 RUN apt-get update && \
     apt-get install -y gcc libpq-dev && \
@@ -9,21 +9,16 @@ RUN pip install --upgrade pip setuptools wheel
 COPY requirements.txt /app/requirements.txt
 RUN pip install --prefix=/install -r /app/requirements.txt
 
-FROM python:3.13-slim-bookworm
+FROM python:3.13-slim
 
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
-    apt-get install -y wget gnupg && \
-    mkdir -p /etc/apt/keyrings && \
-    wget -qO /etc/apt/keyrings/postgres.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
-    echo "deb [signed-by=/etc/apt/keyrings/postgres.asc] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    apt-get install -y --no-install-recommends wget gnupg && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg && \
     apt-get update && \
-    apt-get install -y \
-        postgresql-client-15 \
-        postgresql-client-16 \
-        postgresql-client-17 \
-        postgresql-client-18 && \
+    apt-get install -y --no-install-recommends postgresql-client-18 gzip && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS builder
+FROM python:3.13-slim AS builder
 
 RUN apt-get update && \
     apt-get install -y gcc libpq-dev && \
@@ -15,8 +15,9 @@ ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
     apt-get install -y wget gnupg && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-    wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    mkdir -p /etc/apt/keyrings && \
+    wget -qO /etc/apt/keyrings/postgres.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+    echo "deb [signed-by=/etc/apt/keyrings/postgres.asc] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
     apt-get install -y \
         postgresql-client-15 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim AS builder
+FROM python:3.13-slim-bookworm AS builder
 
 RUN apt-get update && \
     apt-get install -y gcc libpq-dev && \
@@ -9,7 +9,7 @@ RUN pip install --upgrade pip setuptools wheel
 COPY requirements.txt /app/requirements.txt
 RUN pip install --prefix=/install -r /app/requirements.txt
 
-FROM python:3.12-slim
+FROM python:3.13-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim AS builder
+FROM python:3.13-slim-bookworm AS builder
 
 RUN apt-get update && \
     apt-get install -y gcc libpq-dev && \
@@ -9,7 +9,7 @@ RUN pip install --upgrade pip setuptools wheel
 COPY requirements.txt /app/requirements.txt
 RUN pip install --prefix=/install -r /app/requirements.txt
 
-FROM python:3.13-slim
+FROM python:3.13-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,12 @@ FROM python:3.13-slim
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget gnupg && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-    wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg && \
+    apt-get install -y --no-install-recommends \
+        wget gnupg ca-certificates && \
+    mkdir -p /etc/apt/keyrings && \
+    wget -qO /etc/apt/keyrings/postgres.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+    echo "deb [signed-by=/etc/apt/keyrings/postgres.asc] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends postgresql-client-18 gzip && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ FROM python:3.12-slim
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
-    apt-get install -y wget gnupg && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    apt-get install -y wget gnupg lsb-release && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && \
     apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ FROM python:3.12-slim
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
-    apt-get install -y wget gnupg lsb-release && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    apt-get install -y wget gnupg && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && \
     apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,15 @@ FROM python:3.12-slim
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends postgresql-client gzip && \
+    apt-get install -y wget gnupg && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install -y \
+        postgresql-client-15 \
+        postgresql-client-16 \
+        postgresql-client-17 \
+        postgresql-client-18 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install /usr/local

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ You can configure the backup schedule using **Railway Cron Jobs**:
 - Adjust `MAX_BACKUPS` to match your schedule
 
 > If you use Railway Cron Jobs, the service will start once per execution.
-> In this case, the internal scheduler is ignored after startup.
+> In this setup, the service is expected to run a single backup and exit. Any internal scheduler should not be relied on.
+> Ensure the backup process exits cleanly after completion; otherwise, Railway will skip subsequent cron executions.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,7 +42,10 @@ to S3-compatible storage.
 ## Reporting Security Issues
 
 If you discover a security vulnerability, please report it responsibly.
-Do **not** open a public issue with sensitive details.
+
+- Do **not** open a public GitHub issue with sensitive details.
+- Use GitHub’s **Security Advisories** feature to submit a private report.
+
+Security reports will be reviewed and addressed as soon as possible.
 
 > This document describes recommended security practices; exact requirements depend on your deployment environment.
-

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -24,10 +24,23 @@ def mask(value, show=4):
 def doctor():
     print("pg-r2-backup doctor\n")
     
-    if shutil.which("pg_dump") is None:
-        print("[FAIL] pg_dump not found in PATH")
+    if shutil.which("psql") is None:
+        print("[FAIL] psql not found in PATH")
     else:
-        print("[OK] pg_dump found")
+        print("[OK] psql found")
+
+    try:
+        pg_dumps = [f"pg_dump-{v}" for v in ["18", "17", "16", "15"] if shutil.which(f"pg_dump-{v}")]
+
+        if not pg_dumps:
+            print("[FAIL] No pg_dump binaries found")
+        else:
+            preview = ", ".join(sorted(pg_dumps)[:3])
+            more = "..." if len(pg_dumps) > 3 else ""
+            print(f"[OK] Found: {preview}{more}")
+
+    except Exception:
+        print("[WARNING] Unable to check pg_dump binaries")
 
     required_envs = [
         "DATABASE_URL",
@@ -116,7 +129,7 @@ def schedule_info():
 def main():
     parser = argparse.ArgumentParser(
         prog="pg-r2-backup",
-        description="PostgreSQL backup tool for Cloudflare R2",
+        description="PostgreSQL backup tool for S3-compatible storage",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=textwrap.dedent("""
             Examples:

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -24,23 +24,10 @@ def mask(value, show=4):
 def doctor():
     print("pg-r2-backup doctor\n")
     
-    if shutil.which("psql") is None:
-        print("[FAIL] psql not found in PATH")
+    if shutil.which("pg_dump") is None:
+        print("[FAIL] pg_dump not found in PATH")
     else:
-        print("[OK] psql found")
-
-    try:
-        pg_dumps = [f"pg_dump-{v}" for v in ["18", "17", "16", "15"] if shutil.which(f"pg_dump-{v}")]
-
-        if not pg_dumps:
-            print("[FAIL] No pg_dump binaries found")
-        else:
-            preview = ", ".join(sorted(pg_dumps)[:3])
-            more = "..." if len(pg_dumps) > 3 else ""
-            print(f"[OK] Found: {preview}{more}")
-
-    except Exception:
-        print("[WARNING] Unable to check pg_dump binaries")
+        print("[OK] pg_dump found")
 
     required_envs = [
         "DATABASE_URL",

--- a/main.py
+++ b/main.py
@@ -53,41 +53,6 @@ def get_database_url():
         raise ValueError("[ERROR] DATABASE_URL not set!")
     return DATABASE_URL
 
-def get_pg_version(database_url):
-    result = subprocess.run(
-        ["psql", database_url, "-t", "-c", "SHOW server_version;"],
-        capture_output=True,
-        text=True
-    )
-
-    if result.returncode != 0:
-        raise RuntimeError(f"Failed to detect PostgreSQL version: {result.stderr}")
-
-    version = result.stdout.strip()
-
-    if not version:
-        raise RuntimeError("Empty PostgreSQL version returned")
-
-    return version.split(".")[0]
-
-def get_pg_dump(database_url):
-    version = get_pg_version(database_url)
-    candidate = f"pg_dump-{version}"
-
-    if shutil.which(candidate):
-        log(f"[INFO] Using {candidate}")
-        return candidate
-
-    log(f"[WARNING] {candidate} not found, trying latest available...")
-
-    for v in ["18", "17", "16", "15"]:
-        fallback = f"pg_dump-{v}"
-        if shutil.which(fallback):
-            log(f"[INFO] Fallback to {fallback}")
-            return fallback
-
-    return "pg_dump"
-
 def gzip_compress(src):
     dst = src + ".gz"
     with open(src, "rb") as f_in:
@@ -96,8 +61,8 @@ def gzip_compress(src):
     return dst
 
 def run_backup():
-    if shutil.which("psql") is None:
-        log("[ERROR] psql not found. Install postgresql-client.")
+    if shutil.which("pg_dump") is None:
+        log("[ERROR] pg_dump not found. Install postgresql-client.")
         return
 
     database_url = get_database_url()
@@ -125,10 +90,8 @@ def run_backup():
     try:
         log(f"[INFO] Creating backup {backup_file}")
 
-        pg_dump_bin = get_pg_dump(database_url)
-
         dump_cmd = [
-            pg_dump_bin,
+            "pg_dump",
             f"--dbname={database_url}",
             "-F", pg_format,
             "--no-owner",
@@ -136,7 +99,7 @@ def run_backup():
             "-f", backup_file
         ]
 
-        subprocess.run(dump_cmd, check=True, timeout=600)  #10 min
+        subprocess.run(dump_cmd, check=True)
 
         if BACKUP_PASSWORD:
             log("[INFO] Encrypting backup with 7z...")

--- a/main.py
+++ b/main.py
@@ -53,6 +53,41 @@ def get_database_url():
         raise ValueError("[ERROR] DATABASE_URL not set!")
     return DATABASE_URL
 
+def get_pg_version(database_url):
+    result = subprocess.run(
+        ["psql", database_url, "-t", "-c", "SHOW server_version;"],
+        capture_output=True,
+        text=True
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to detect PostgreSQL version: {result.stderr}")
+
+    version = result.stdout.strip()
+
+    if not version:
+        raise RuntimeError("Empty PostgreSQL version returned")
+
+    return version.split(".")[0]
+
+def get_pg_dump(database_url):
+    version = get_pg_version(database_url)
+    candidate = f"pg_dump-{version}"
+
+    if shutil.which(candidate):
+        log(f"[INFO] Using {candidate}")
+        return candidate
+
+    log(f"[WARNING] {candidate} not found, trying latest available...")
+
+    for v in ["18", "17", "16", "15"]:
+        fallback = f"pg_dump-{v}"
+        if shutil.which(fallback):
+            log(f"[INFO] Fallback to {fallback}")
+            return fallback
+
+    return "pg_dump"
+
 def gzip_compress(src):
     dst = src + ".gz"
     with open(src, "rb") as f_in:
@@ -61,8 +96,8 @@ def gzip_compress(src):
     return dst
 
 def run_backup():
-    if shutil.which("pg_dump") is None:
-        log("[ERROR] pg_dump not found. Install postgresql-client.")
+    if shutil.which("psql") is None:
+        log("[ERROR] psql not found. Install postgresql-client.")
         return
 
     database_url = get_database_url()
@@ -90,8 +125,10 @@ def run_backup():
     try:
         log(f"[INFO] Creating backup {backup_file}")
 
+        pg_dump_bin = get_pg_dump(database_url)
+
         dump_cmd = [
-            "pg_dump",
+            pg_dump_bin,
             f"--dbname={database_url}",
             "-F", pg_format,
             "--no-owner",
@@ -99,7 +136,7 @@ def run_backup():
             "-f", backup_file
         ]
 
-        subprocess.run(dump_cmd, check=True)
+        subprocess.run(dump_cmd, check=True, timeout=600)  #10 min
 
         if BACKUP_PASSWORD:
             log("[INFO] Encrypting backup with 7z...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pg-r2-backup"
-version = "1.0.6"
-description = "PostgreSQL backup tool for Cloudflare R2 (S3 Compatible)"
+version = "1.0.7"
+description = "PostgreSQL backup automation tool for S3-compatible storage"
 readme = "README.md"
 requires-python = ">=3.9"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.42.46
+boto3==1.42.73
 psycopg2-binary==2.9.10
 python-dotenv==1.2.1
 py7zr==1.1.0


### PR DESCRIPTION
### 🔧 Fix pg_dump version mismatch

This PR fixes a backup failure caused by a PostgreSQL version mismatch:

- Railway database upgraded to PostgreSQL 18
- Container was using pg_dump 17 → caused backup failure

### ✅ Changes
- Installed `postgresql-client-18` from PGDG repository
- Switched base image to `python:3.13-slim-bookworm` for compatibility
- Added proper keyring setup for PostgreSQL APT repo
- Fixed missing dependency copy from builder stage

### 🚀 Result
- pg_dump is now version 18 (compatible with Railway DB)
- Backups run successfully again
- Maintains backward compatibility with PostgreSQL 15–17

### 🧠 Notes
- pg_dump must be >= server version
- Bookworm image is pinned to avoid future breaking changes (e.g. trixie)
