### PR TITLE
fix: add RUN_ONCE mode for Railway cron support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ BACKUP_TIME=00:00
 
 # Keep backup file locally after upload (not recommended on PaaS platforms)
 KEEP_LOCAL_BACKUP=false
+
+# Run once and exit (for cron jobs / Railway cron)
+RUN_ONCE=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim AS builder
+FROM python:3.13-slim-bookworm AS builder
 
 RUN apt-get update && \
     apt-get install -y gcc libpq-dev && \
@@ -9,14 +9,17 @@ RUN pip install --upgrade pip setuptools wheel
 COPY requirements.txt /app/requirements.txt
 RUN pip install --prefix=/install -r /app/requirements.txt
 
-FROM python:3.13-slim
+FROM python:3.13-slim-bookworm
 
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget gnupg && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-    wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg && \
+    apt-get install -y --no-install-recommends \
+        wget gnupg ca-certificates && \
+    mkdir -p /etc/apt/keyrings && \
+    wget -qO /etc/apt/keyrings/postgres.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+    echo "deb [signed-by=/etc/apt/keyrings/postgres.asc] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends postgresql-client-18 gzip && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ R2_ACCESS_KEY=          # Access key
 R2_SECRET_KEY=          # Secret key
 S3_REGION=us-east-1     # Required for AWS S3 (ignored by R2/MinIO)
 
+RUN_ONCE=false          # Run once and exit (set true for Railway Cron)
 BACKUP_PASSWORD=        # Optional: enables 7z encryption
 BACKUP_TIME=00:00       # Daily backup time (UTC, HH:MM)
 ```
@@ -117,6 +118,23 @@ You can configure the backup schedule using **Railway Cron Jobs**:
 > If you use Railway Cron Jobs, the service will start once per execution.
 > In this setup, the service is expected to run a single backup and exit. Any internal scheduler should not be relied on.
 > Ensure the backup process exits cleanly after completion; otherwise, Railway will skip subsequent cron executions.
+
+---
+
+### 🔁 Cron Mode (Important)
+
+When using Railway Cron Jobs, you must enable one-shot mode:
+
+```env
+RUN_ONCE=true
+```
+
+This ensures the service:
+
+runs a single backup
+exits cleanly after completion
+
+If not set, the service will run continuously and future cron executions may be skipped.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ R2_ACCESS_KEY=          # Access key
 R2_SECRET_KEY=          # Secret key
 S3_REGION=us-east-1     # Required for AWS S3 (ignored by R2/MinIO)
 
-RUN_ONCE=false          # Run once and exit (set true for Railway Cron)
+RUN_ONCE=false          # Run once and exit instead of scheduler (set true for Railway Cron)
 BACKUP_PASSWORD=        # Optional: enables 7z encryption
 BACKUP_TIME=00:00       # Daily backup time (UTC, HH:MM)
 ```
@@ -131,10 +131,13 @@ RUN_ONCE=true
 
 This ensures the service:
 
-runs a single backup
-exits cleanly after completion
+- runs a single backup  
+- exits cleanly after completion  
 
 If not set, the service will run continuously and future cron executions may be skipped.
+
+> `BACKUP_TIME` is only used when `RUN_ONCE=false` (daemon mode).  
+> When using Railway Cron (`RUN_ONCE=true`), scheduling is controlled by Railway.
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -192,11 +192,7 @@ if __name__ == "__main__":
 
     success = run_backup()
 
-    log(f"[DEBUG] run_backup() finished with success={success}")
-    log(f"[DEBUG] RUN_ONCE={RUN_ONCE}")
-
     if RUN_ONCE:
-        log("[DEBUG] Exiting now...")
         sys.exit(0 if success else 1)
 
     log(f"[INFO] Scheduled backup time: {BACKUP_TIME} UTC")

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import schedule
 import py7zr
 import shutil
 import gzip
+import sys 
 
 load_dotenv(find_dotenv(usecwd=True), override=True)
 
@@ -30,6 +31,8 @@ BACKUP_PASSWORD = os.environ.get("BACKUP_PASSWORD")
 USE_PUBLIC_URL = os.environ.get("USE_PUBLIC_URL", "false").lower() == "true"
 BACKUP_TIME = os.environ.get("BACKUP_TIME", "00:00")
 S3_REGION = os.environ.get("S3_REGION", "us-east-1")
+RUN_ONCE = os.environ.get("RUN_ONCE", "false").lower() == "true"
+
 
 def log(msg):
     print(msg, flush=True)
@@ -61,9 +64,10 @@ def gzip_compress(src):
     return dst
 
 def run_backup():
+    success = True
     if shutil.which("pg_dump") is None:
         log("[ERROR] pg_dump not found. Install postgresql-client.")
-        return
+        return False
 
     database_url = get_database_url()
     log(f"[INFO] Using {'public' if USE_PUBLIC_URL else 'private'} database URL")
@@ -113,10 +117,11 @@ def run_backup():
 
     except subprocess.CalledProcessError as e:
         log(f"[ERROR] Backup creation failed: {e}")
-        return
+        return False
     finally:
         if os.path.exists(backup_file):
             os.remove(backup_file)
+            
 
     ## Upload to R2
     if os.path.exists(compressed_file):
@@ -172,21 +177,28 @@ def run_backup():
 
     except Exception as e:
         log(f"[ERROR] R2 operation failed: {e}")
+        return False
     finally:
         if os.path.exists(compressed_file):
                 if KEEP_LOCAL_BACKUP:
                     log("[INFO] Keeping local backup (KEEP_LOCAL_BACKUP=true)")
                 else:
                     os.remove(compressed_file)
-                    log("[INFO] Local backup deleted")
+                    log("[INFO] Local backup deleted")                
+    return success
+
 
 if __name__ == "__main__":
-    log("[INFO] Starting backup scheduler...")
+    log("[INFO] Starting backup process...")
+
+    success = run_backup()
+
+    if RUN_ONCE:
+        sys.exit(0 if success else 1)
+
     log(f"[INFO] Scheduled backup time: {BACKUP_TIME} UTC")
 
     schedule.every().day.at(BACKUP_TIME).do(run_backup)
-
-    run_backup()
 
     while True:
         schedule.run_pending()

--- a/main.py
+++ b/main.py
@@ -193,7 +193,11 @@ if __name__ == "__main__":
 
     success = run_backup()
 
+    log(f"[DEBUG] run_backup() finished with success={success}")
+    log(f"[DEBUG] RUN_ONCE={RUN_ONCE}")
+
     if RUN_ONCE:
+        log("[DEBUG] Exiting now...")
         sys.exit(0 if success else 1)
 
     log(f"[INFO] Scheduled backup time: {BACKUP_TIME} UTC")

--- a/main.py
+++ b/main.py
@@ -187,7 +187,6 @@ def run_backup():
                     log("[INFO] Local backup deleted")                
     return success
 
-
 if __name__ == "__main__":
     log("[INFO] Starting backup process...")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pg-r2-backup"
-version = "1.0.7"
+version = "1.0.8"
 description = "PostgreSQL backup automation tool for S3-compatible storage"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-boto3==1.42.73
-psycopg2-binary==2.9.10
+boto3==1.42.96 
+psycopg2-binary==2.9.12 
 python-dotenv==1.2.1
 py7zr==1.1.0
 schedule==1.2.2


### PR DESCRIPTION
## Summary

This update adds support for running the backup process in one shot mode, making it compatible with Railway Cron Jobs.

## Changes

- Added `RUN_ONCE` environment variable
- App exits after a single backup when `RUN_ONCE=true`
- Keeps existing scheduler behavior when `RUN_ONCE=false`
- Updated README with cron usage instructions
- Added clarification for `BACKUP_TIME` behavior

## Why

Railway Cron requires services to:
- run a task
- exit after completion

Previously, the app ran as a long lived scheduler, causing cron executions to be skipped.

## Usage

For Railway Cron:

```env
RUN_ONCE=true